### PR TITLE
Add option to set a ratelimit buffer

### DIFF
--- a/.github/workflows/lock.yaml
+++ b/.github/workflows/lock.yaml
@@ -23,6 +23,6 @@ jobs:
       - uses: ./
         with:
           days-inactive-issues: 30
-          days-inactive-prs: 30
+          days-inactive-prs: 1
           lock-reason-issues: ""
           lock-reason-prs: ""

--- a/__tests__/issues.test.ts
+++ b/__tests__/issues.test.ts
@@ -1,28 +1,28 @@
-import * as core from "@actions/core";
-import * as github from "@actions/github";
-import { processIssues } from "../src/index";
-import { describe, expect, it, jest, beforeEach } from "@jest/globals";
+import * as core from '@actions/core'
+import * as github from '@actions/github'
+import { processIssues } from '../src/index'
+import { describe, expect, it, jest, beforeEach } from '@jest/globals'
 
-jest.mock("@actions/core");
-jest.mock("@actions/github");
+jest.mock('@actions/core')
+jest.mock('@actions/github')
 
-const mockCore = core as jest.Mocked<typeof core>;
-const mockGithub = github as jest.Mocked<typeof github>;
+const mockCore = core as jest.Mocked<typeof core>
+const mockGithub = github as jest.Mocked<typeof github>
 
-describe("GitHub Action - Lock issues", () => {
-  let mockOctokit: any;
+describe('GitHub Action - Lock issues', () => {
+  let mockOctokit: any
 
   beforeEach(() => {
-    jest.clearAllMocks();
+    jest.clearAllMocks()
 
     // Mock context.repo using Object.defineProperty
-    Object.defineProperty(mockGithub.context, "repo", {
+    Object.defineProperty(mockGithub.context, 'repo', {
       value: {
-        owner: "test-owner",
-        repo: "test-repo",
+        owner: 'test-owner',
+        repo: 'test-repo',
       },
       writable: true, // Ensure it can be modified
-    });
+    })
 
     // Mock Octokit instance with rate limit functionality
     mockOctokit = {
@@ -43,22 +43,22 @@ describe("GitHub Action - Lock issues", () => {
                   },
                 },
               },
-            });
+            })
           }),
         },
       },
-    };
+    }
 
-    mockGithub.getOctokit.mockReturnValue(mockOctokit);
-  });
+    mockGithub.getOctokit.mockReturnValue(mockOctokit)
+  })
 
-  it("should process closed issues and lock inactive ones", async () => {
+  it('should process closed issues and lock inactive ones', async () => {
     mockCore.getInput.mockImplementation((name) => {
-      if (name === "repo-token") return "fake-token";
-      if (name === "days-inactive-issues") return "30";
-      if (name === "lock-reason-issues") return "off-topic";
-      return "";
-    });
+      if (name === 'repo-token') return 'fake-token'
+      if (name === 'days-inactive-issues') return '30'
+      if (name === 'lock-reason-issues') return 'off-topic'
+      return ''
+    })
 
     // Mock response for listForRepo
     mockOctokit.rest.issues.listForRepo.mockImplementation(
@@ -70,54 +70,60 @@ describe("GitHub Action - Lock issues", () => {
               {
                 number: 1,
                 pull_request: null,
-                updated_at: "2023-06-29T12:00:00Z", // Assuming this issue is inactive
+                updated_at: '2023-06-29T12:00:00Z', // Assuming this issue is inactive
               },
             ],
-          };
+          }
         } else {
           return {
             data: [], // Simulate no more issues on subsequent pages
-          };
+          }
         }
-      }
-    );
+      },
+    )
 
-    const mockLock = jest.fn().mockResolvedValue({});
-    mockOctokit.rest.issues.lock.mockImplementationOnce(mockLock);
+    // @ts-ignore - Ignore missing properties
+    const mockLock = jest.fn().mockResolvedValue({})
+    mockOctokit.rest.issues.lock.mockImplementationOnce(mockLock)
 
     await processIssues(
       mockOctokit,
-      "test-owner",
-      "test-repo",
+      'test-owner',
+      'test-repo',
       30,
-      "off-topic",
-      100
-    );
+      'off-topic',
+      100,
+      100,
+    )
+
+    expect(mockCore.info).toHaveBeenCalledWith(
+      'Processing issues - page 1 for test-owner/test-repo.',
+    )
 
     expect(mockOctokit.rest.issues.listForRepo).toHaveBeenCalledWith({
-      owner: "test-owner",
-      repo: "test-repo",
-      state: "closed",
+      owner: 'test-owner',
+      repo: 'test-repo',
+      state: 'closed',
       per_page: 100,
       page: 1,
-    });
+    })
 
     expect(mockOctokit.rest.issues.lock).toHaveBeenCalledWith({
-      owner: "test-owner",
-      repo: "test-repo",
+      owner: 'test-owner',
+      repo: 'test-repo',
       issue_number: 1,
-      lock_reason: "off-topic",
-    });
-  });
+      lock_reason: 'off-topic',
+    })
+  })
 
-  it("should not lock issues that are less than 30 days inactive", async () => {
+  it('should not lock issues that are less than 30 days inactive', async () => {
     mockCore.getInput.mockImplementation((name) => {
-      if (name === "repo-token") return "fake-token";
-      if (name === "days-inactive-issues") return "30";
-      if (name === "lock-reason-issues") return "off-topic";
-      return "";
-    });
-  
+      if (name === 'repo-token') return 'fake-token'
+      if (name === 'days-inactive-issues') return '30'
+      if (name === 'lock-reason-issues') return 'off-topic'
+      return ''
+    })
+
     // Mock response for listForRepo
     mockOctokit.rest.issues.listForRepo.mockImplementation(
       async ({ owner, repo, state, per_page, page }) => {
@@ -131,32 +137,41 @@ describe("GitHub Action - Lock issues", () => {
                 updated_at: new Date().toISOString(), // Date is current
               },
             ],
-          };
+          }
         } else {
           return {
             data: [], // Simulate no more issues on subsequent pages
-          };
+          }
         }
-      }
-    );
+      },
+    )
 
-    const mockLock = jest.fn().mockResolvedValue({});
-    mockOctokit.rest.issues.lock.mockImplementationOnce(mockLock);
+    // @ts-ignore - Ignore missing properties
+    const mockLock = jest.fn().mockResolvedValue({})
+    mockOctokit.rest.issues.lock.mockImplementationOnce(mockLock)
 
-    await processIssues(mockOctokit, "test-owner", "test-repo", 30, "off-topic", 100);
-  
+    await processIssues(
+      mockOctokit,
+      'test-owner',
+      'test-repo',
+      30,
+      'off-topic',
+      100,
+      100,
+    )
+
     expect(mockOctokit.rest.issues.listForRepo).toHaveBeenCalledWith({
-      owner: "test-owner",
-      repo: "test-repo",
-      state: "closed",
+      owner: 'test-owner',
+      repo: 'test-repo',
+      state: 'closed',
       per_page: 100,
       page: 1,
-    });
+    })
 
-    expect(mockLock).not.toHaveBeenCalled(); // Ensure lock function is not called
-  });
+    expect(mockLock).not.toHaveBeenCalled() // Ensure lock function is not called
+  })
 
-  it("should warn when rate limit is exceeded during issue locking", async () => {
+  it('should warn when rate limit is exceeded during issue locking', async () => {
     // Set remaining rate limit to 0 to simulate rate limit exceeded
     mockOctokit.rest.rateLimit.get.mockResolvedValueOnce({
       data: {
@@ -167,28 +182,29 @@ describe("GitHub Action - Lock issues", () => {
           },
         },
       },
-    });
+    })
 
     mockCore.getInput.mockImplementation((name) => {
-      if (name === "repo-token") return "fake-token";
-      if (name === "days-inactive-issues") return "30";
-      if (name === "lock-reason-issues") return "off-topic";
-      return "";
-    });
+      if (name === 'repo-token') return 'fake-token'
+      if (name === 'days-inactive-issues') return '30'
+      if (name === 'lock-reason-issues') return 'off-topic'
+      return ''
+    })
 
     await processIssues(
       mockOctokit,
-      "test-owner",
-      "test-repo",
+      'test-owner',
+      'test-repo',
       30,
-      "off-topic",
-      100
-    );
+      'off-topic',
+      100,
+      100,
+    )
 
     expect(mockCore.warning).toHaveBeenCalledWith(
-      expect.stringContaining("Rate limit exceeded")
-    );
-    expect(mockOctokit.rest.issues.listForRepo).not.toHaveBeenCalled();
-    expect(mockOctokit.rest.issues.lock).not.toHaveBeenCalled();
-  });
-});
+      expect.stringContaining('Rate limit exceeded'),
+    )
+    expect(mockOctokit.rest.issues.listForRepo).not.toHaveBeenCalled()
+    expect(mockOctokit.rest.issues.lock).not.toHaveBeenCalled()
+  })
+})

--- a/__tests__/pull_requests.test.ts
+++ b/__tests__/pull_requests.test.ts
@@ -1,28 +1,28 @@
-import * as core from "@actions/core";
-import * as github from "@actions/github";
-import { processPullRequests } from "../src/index";
-import { describe, expect, it, jest, beforeEach } from "@jest/globals";
+import * as core from '@actions/core'
+import * as github from '@actions/github'
+import { processPullRequests } from '../src/index'
+import { describe, expect, it, jest, beforeEach } from '@jest/globals'
 
-jest.mock("@actions/core");
-jest.mock("@actions/github");
+jest.mock('@actions/core')
+jest.mock('@actions/github')
 
-const mockCore = core as jest.Mocked<typeof core>;
-const mockGithub = github as jest.Mocked<typeof github>;
+const mockCore = core as jest.Mocked<typeof core>
+const mockGithub = github as jest.Mocked<typeof github>
 
-describe("GitHub Action - Lock PRs", () => {
-  let mockOctokit: any;
+describe('GitHub Action - Lock PRs', () => {
+  let mockOctokit: any
 
   beforeEach(() => {
-    jest.clearAllMocks();
+    jest.clearAllMocks()
 
     // Mock context.repo using Object.defineProperty
-    Object.defineProperty(mockGithub.context, "repo", {
+    Object.defineProperty(mockGithub.context, 'repo', {
       value: {
-        owner: "test-owner",
-        repo: "test-repo",
+        owner: 'test-owner',
+        repo: 'test-repo',
       },
       writable: true, // Ensure it can be modified
-    });
+    })
 
     // Mock Octokit instance with rate limit functionality
     mockOctokit = {
@@ -45,22 +45,22 @@ describe("GitHub Action - Lock PRs", () => {
                   },
                 },
               },
-            });
+            })
           }),
         },
       },
-    };
+    }
 
-    mockGithub.getOctokit.mockReturnValue(mockOctokit);
-  });
+    mockGithub.getOctokit.mockReturnValue(mockOctokit)
+  })
 
-  it("should process closed PRs and lock inactive ones", async () => {
+  it('should process closed PRs and lock inactive ones', async () => {
     mockCore.getInput.mockImplementation((name) => {
-      if (name === "repo-token") return "fake-token";
-      if (name === "days-inactive-prs") return "30";
-      if (name === "lock-reason-prs") return "off-topic";
-      return "";
-    });
+      if (name === 'repo-token') return 'fake-token'
+      if (name === 'days-inactive-prs') return '30'
+      if (name === 'lock-reason-prs') return 'off-topic'
+      return ''
+    })
 
     mockOctokit.rest.pulls.list.mockImplementation(
       async ({ owner, repo, state, per_page, page }) => {
@@ -70,54 +70,60 @@ describe("GitHub Action - Lock PRs", () => {
             data: [
               {
                 number: 1,
-                updated_at: "2023-05-29T12:00:00Z", // Assuming this issue is inactive
+                updated_at: '2023-05-29T12:00:00Z', // Assuming this issue is inactive
               },
             ],
-          };
+          }
         } else {
           return {
             data: [], // Simulate no more PRs on subsequent pages
-          };
+          }
         }
-      }
-    );
+      },
+    )
 
-    const mockLock = jest.fn().mockResolvedValue({});
-    mockOctokit.rest.issues.lock.mockImplementationOnce(mockLock);
+    // @ts-ignore - Ignore missing properties
+    const mockLock = jest.fn().mockResolvedValue({})
+    mockOctokit.rest.issues.lock.mockImplementationOnce(mockLock)
 
     await processPullRequests(
       mockOctokit,
-      "test-owner",
-      "test-repo",
+      'test-owner',
+      'test-repo',
       30,
-      "off-topic",
-      100
-    );
+      'off-topic',
+      100,
+      100,
+    )
+
+    expect(mockCore.info).toHaveBeenCalledWith(
+      'Processing pull requests - page 1 for test-owner/test-repo.',
+    )
 
     expect(mockOctokit.rest.pulls.list).toHaveBeenCalledWith({
-      owner: "test-owner",
-      repo: "test-repo",
-      state: "closed",
+      owner: 'test-owner',
+      repo: 'test-repo',
+      state: 'closed',
       per_page: 100,
       page: 1,
-    });
+    })
 
     expect(mockOctokit.rest.issues.lock).toHaveBeenCalledWith({
-      owner: "test-owner",
-      repo: "test-repo",
+      owner: 'test-owner',
+      repo: 'test-repo',
       issue_number: 1,
-      lock_reason: "off-topic",
-    });
-  });
+      lock_reason: 'off-topic',
+    })
+  })
 
-  it("should not lock PRs that are less than 30 days inactive", async () => {
+  it('should not lock PRs that are less than 30 days inactive', async () => {
     mockCore.getInput.mockImplementation((name) => {
-      if (name === "repo-token") return "fake-token";
-      if (name === "days-inactive-prs") return "30";
-      if (name === "lock-reason-prs") return "off-topic";
-      return "";
-    });
-  
+      if (name === 'repo-token') return 'fake-token'
+      if (name === 'days-inactive-prs') return '30'
+      if (name === 'lock-reason-prs') return 'off-topic'
+      return ''
+    })
+
     // Mock response for pulls.list
     mockOctokit.rest.pulls.list.mockImplementation(
       async ({ owner, repo, state, per_page, page }) => {
@@ -130,32 +136,41 @@ describe("GitHub Action - Lock PRs", () => {
                 updated_at: new Date().toISOString(), // Date is current
               },
             ],
-          };
+          }
         } else {
           return {
             data: [], // Simulate no more issues on subsequent pages
-          };
+          }
         }
-      }
-    );
+      },
+    )
 
-    const mockLock = jest.fn().mockResolvedValue({});
-    mockOctokit.rest.issues.lock.mockImplementationOnce(mockLock);
+    // @ts-ignore - Ignore missing properties
+    const mockLock = jest.fn().mockResolvedValue({})
+    mockOctokit.rest.issues.lock.mockImplementationOnce(mockLock)
 
-    await processPullRequests(mockOctokit, "test-owner", "test-repo", 30, "off-topic", 100);
-  
+    await processPullRequests(
+      mockOctokit,
+      'test-owner',
+      'test-repo',
+      30,
+      'off-topic',
+      100,
+      100,
+    )
+
     expect(mockOctokit.rest.pulls.list).toHaveBeenCalledWith({
-      owner: "test-owner",
-      repo: "test-repo",
-      state: "closed",
+      owner: 'test-owner',
+      repo: 'test-repo',
+      state: 'closed',
       per_page: 100,
       page: 1,
-    });
+    })
 
-    expect(mockLock).not.toHaveBeenCalled(); // Ensure lock function is not called
-  });
+    expect(mockLock).not.toHaveBeenCalled() // Ensure lock function is not called
+  })
 
-  it("should warn when rate limit is exceeded during PR locking", async () => {
+  it('should warn when rate limit is exceeded during PR locking', async () => {
     // Set remaining rate limit to 0 to simulate rate limit exceeded
     mockOctokit.rest.rateLimit.get.mockResolvedValueOnce({
       data: {
@@ -166,28 +181,29 @@ describe("GitHub Action - Lock PRs", () => {
           },
         },
       },
-    });
+    })
 
     mockCore.getInput.mockImplementation((name) => {
-      if (name === "repo-token") return "fake-token";
-      if (name === "days-inactive-prs") return "30";
-      if (name === "lock-reason-prs") return "off-topic";
-      return "";
-    });
+      if (name === 'repo-token') return 'fake-token'
+      if (name === 'days-inactive-prs') return '30'
+      if (name === 'lock-reason-prs') return 'off-topic'
+      return ''
+    })
 
     await processPullRequests(
       mockOctokit,
-      "test-owner",
-      "test-repo",
+      'test-owner',
+      'test-repo',
       30,
-      "off-topic",
-      100
-    );
+      'off-topic',
+      100,
+      100,
+    )
 
     expect(mockCore.warning).toHaveBeenCalledWith(
-      expect.stringContaining("Rate limit exceeded")
-    );
-    expect(mockOctokit.rest.pulls.list).not.toHaveBeenCalled();
-    expect(mockOctokit.rest.issues.lock).not.toHaveBeenCalled();
-  });
-});
+      expect.stringContaining('Rate limit exceeded'),
+    )
+    expect(mockOctokit.rest.pulls.list).not.toHaveBeenCalled()
+    expect(mockOctokit.rest.issues.lock).not.toHaveBeenCalled()
+  })
+})

--- a/__tests__/ratelimit.test.ts
+++ b/__tests__/ratelimit.test.ts
@@ -1,28 +1,28 @@
-import * as core from "@actions/core";
-import * as github from "@actions/github";
-import { run, checkRateLimit } from "../src/index";
-import { describe, expect, it, jest, beforeEach } from "@jest/globals";
+import * as core from '@actions/core'
+import * as github from '@actions/github'
+import { run, checkRateLimit } from '../src/index'
+import { describe, expect, it, jest, beforeEach } from '@jest/globals'
 
-jest.mock("@actions/core");
-jest.mock("@actions/github");
+jest.mock('@actions/core')
+jest.mock('@actions/github')
 
-const mockCore = core as jest.Mocked<typeof core>;
-const mockGithub = github as jest.Mocked<typeof github>;
+const mockCore = core as jest.Mocked<typeof core>
+const mockGithub = github as jest.Mocked<typeof github>
 
-describe("GitHub Action - Rate Limit Handling", () => {
-  let mockOctokit: any;
+describe('GitHub Action - Rate Limit Handling', () => {
+  let mockOctokit: any
 
   beforeEach(() => {
-    jest.clearAllMocks();
+    jest.clearAllMocks()
 
     // Mock context.repo using Object.defineProperty
-    Object.defineProperty(mockGithub.context, "repo", {
+    Object.defineProperty(mockGithub.context, 'repo', {
       value: {
-        owner: "test-owner",
-        repo: "test-repo",
+        owner: 'test-owner',
+        repo: 'test-repo',
       },
       writable: true, // Ensure it can be modified
-    });
+    })
 
     // Mock Octokit instance with rate limit functionality
     mockOctokit = {
@@ -46,16 +46,16 @@ describe("GitHub Action - Rate Limit Handling", () => {
                   },
                 },
               },
-            });
+            })
           }),
         },
       },
-    };
+    }
 
-    mockGithub.getOctokit.mockReturnValue(mockOctokit);
-  });
+    mockGithub.getOctokit.mockReturnValue(mockOctokit)
+  })
 
-  it("should check rate limit status", async () => {
+  it('should check rate limit status', async () => {
     const mockRateLimitResponse = {
       data: {
         resources: {
@@ -65,13 +65,13 @@ describe("GitHub Action - Rate Limit Handling", () => {
           },
         },
       },
-    };
+    }
 
     const expectedRemaining =
-      mockRateLimitResponse.data.resources.core.remaining;
-    const expectedReset = mockRateLimitResponse.data.resources.core.reset;
+      mockRateLimitResponse.data.resources.core.remaining
+    const expectedReset = mockRateLimitResponse.data.resources.core.reset
 
-    const mockGetRateLimit = jest.fn().mockResolvedValue(mockRateLimitResponse);
+    const mockGetRateLimit = jest.fn().mockResolvedValue(mockRateLimitResponse)
 
     mockGithub.getOctokit.mockReturnValue({
       rest: {
@@ -79,20 +79,20 @@ describe("GitHub Action - Rate Limit Handling", () => {
           get: mockGetRateLimit,
         },
       },
-    });
+    })
 
     const rateLimitStatus = await checkRateLimit(
-      mockGithub.getOctokit("fake-token")
-    );
+      mockGithub.getOctokit('fake-token'),
+    )
 
-    expect(mockGetRateLimit).toHaveBeenCalled();
-    expect(rateLimitStatus.remaining).toEqual(expectedRemaining);
+    expect(mockGetRateLimit).toHaveBeenCalled()
+    expect(rateLimitStatus.remaining).toEqual(expectedRemaining)
     expect(rateLimitStatus.resetTime).toEqual(
-      expectedReset - Math.floor(Date.now() / 1000)
-    );
-  });
+      expectedReset - Math.floor(Date.now() / 1000),
+    )
+  })
 
-  it("should warn and stop processing if initial rate limit is exceeded", async () => {
+  it('should warn and stop processing if initial rate limit is exceeded', async () => {
     // Set remaining rate limit to 0 to simulate rate limit exceeded
     mockOctokit.rest.rateLimit.get.mockResolvedValueOnce({
       data: {
@@ -103,45 +103,47 @@ describe("GitHub Action - Rate Limit Handling", () => {
           },
         },
       },
-    });
+    })
 
     mockCore.getInput.mockImplementation((name) => {
-      if (name === "repo-token") return "fake-token";
-      if (name === "days-inactive-issues") return "30";
-      if (name === "days-inactive-prs") return "30";
-      if (name === "lock-reason-issues") return "off-topic";
-      if (name === "lock-reason-prs") return "off-topic";
-      return "";
-    });
+      if (name === 'repo-token') return 'fake-token'
+      if (name === 'rate-limit-buffer') return '100'
+      if (name === 'days-inactive-issues') return '30'
+      if (name === 'days-inactive-prs') return '1'
+      if (name === 'lock-reason-issues') return 'off-topic'
+      if (name === 'lock-reason-prs') return 'off-topic'
+      return ''
+    })
 
-    await run();
+    await run()
 
     expect(mockCore.warning).toHaveBeenCalledWith(
-      "Initial rate limit exceeded, stopping processing."
-    );
-  });
+      'Initial rate limit too low, stopping processing.',
+    )
+  })
 
-  it("should process issues and pull requests if rate limit allows", async () => {
+  it('should process issues and pull requests if rate limit allows', async () => {
     // Set remaining rate limit to 100 to simulate enough remaining calls
     mockOctokit.rest.rateLimit.get.mockResolvedValueOnce({
       data: {
         resources: {
           core: {
-            remaining: 100,
+            remaining: 200,
             reset: Math.floor(Date.now() / 1000) + 3600, // Reset time in future
           },
         },
       },
-    });
+    })
 
     mockCore.getInput.mockImplementation((name) => {
-      if (name === "repo-token") return "fake-token";
-      if (name === "days-inactive-issues") return "30";
-      if (name === "days-inactive-prs") return "30";
-      if (name === "lock-reason-issues") return "off-topic";
-      if (name === "lock-reason-prs") return "off-topic";
-      return "";
-    });
+      if (name === 'repo-token') return 'fake-token'
+      if (name === 'rate-limit-buffer') return '100'
+      if (name === 'days-inactive-issues') return '30'
+      if (name === 'days-inactive-prs') return '30'
+      if (name === 'lock-reason-issues') return 'off-topic'
+      if (name === 'lock-reason-prs') return 'off-topic'
+      return ''
+    })
 
     // Mock response for listForRepo
     mockOctokit.rest.issues.listForRepo.mockImplementation(
@@ -153,17 +155,17 @@ describe("GitHub Action - Rate Limit Handling", () => {
               {
                 number: 1,
                 pull_request: null,
-                updated_at: "2023-06-29T12:00:00Z", // Assuming this issue is inactive
+                updated_at: '2023-06-29T12:00:00Z', // Assuming this issue is inactive
               },
             ],
-          };
+          }
         } else {
           return {
             data: [], // Simulate no more issues on subsequent pages
-          };
+          }
         }
-      }
-    );
+      },
+    )
 
     // Mock response for list
     mockOctokit.rest.pulls.list.mockImplementation(
@@ -174,22 +176,22 @@ describe("GitHub Action - Rate Limit Handling", () => {
             data: [
               {
                 number: 1,
-                updated_at: "2023-05-29T12:00:00Z", // Assuming this issue is inactive
+                updated_at: '2023-05-29T12:00:00Z', // Assuming this issue is inactive
               },
             ],
-          };
+          }
         } else {
           return {
             data: [], // Simulate no more PRs on subsequent pages
-          };
+          }
         }
-      }
-    );
+      },
+    )
 
-    await run();
+    await run()
 
     // Ensure processing functions were called
-    expect(mockOctokit.rest.issues.listForRepo).toHaveBeenCalled();
-    expect(mockOctokit.rest.pulls.list).toHaveBeenCalled();
-  });
-});
+    expect(mockOctokit.rest.issues.listForRepo).toHaveBeenCalled()
+    expect(mockOctokit.rest.pulls.list).toHaveBeenCalled()
+  })
+})

--- a/__tests__/run.test.ts
+++ b/__tests__/run.test.ts
@@ -1,28 +1,28 @@
-import * as core from "@actions/core";
-import * as github from "@actions/github";
-import { run, processIssues, checkRateLimit, processPullRequests } from "../src/index";
-import { describe, expect, it, jest, beforeEach } from "@jest/globals";
+import * as core from '@actions/core'
+import * as github from '@actions/github'
+import { run, checkRateLimit } from '../src/index'
+import { describe, expect, it, jest, beforeEach } from '@jest/globals'
 
-jest.mock("@actions/core");
-jest.mock("@actions/github");
+jest.mock('@actions/core')
+jest.mock('@actions/github')
 
-const mockCore = core as jest.Mocked<typeof core>;
-const mockGithub = github as jest.Mocked<typeof github>;
+const mockCore = core as jest.Mocked<typeof core>
+const mockGithub = github as jest.Mocked<typeof github>
 
-describe("GitHub Action - Rate Limit Handling", () => {
-  let mockOctokit: any;
+describe('GitHub Action - Run', () => {
+  let mockOctokit: any
 
   beforeEach(() => {
-    jest.clearAllMocks();
+    jest.clearAllMocks()
 
     // Mock context.repo using Object.defineProperty
-    Object.defineProperty(mockGithub.context, "repo", {
+    Object.defineProperty(mockGithub.context, 'repo', {
       value: {
-        owner: "test-owner",
-        repo: "test-repo",
+        owner: 'test-owner',
+        repo: 'test-repo',
       },
       writable: true, // Ensure it can be modified
-    });
+    })
 
     // Mock Octokit instance with rate limit functionality
     mockOctokit = {
@@ -46,150 +46,34 @@ describe("GitHub Action - Rate Limit Handling", () => {
                   },
                 },
               },
-            });
+            })
           }),
         },
       },
-    };
+    }
 
-    mockGithub.getOctokit.mockReturnValue(mockOctokit);
-  });
+    mockGithub.getOctokit.mockReturnValue(mockOctokit)
+  })
 
-  it("should check rate limit status", async () => {
-    const mockRateLimitResponse = {
-      data: {
-        resources: {
-          core: {
-            remaining: 5000,
-            reset: Math.floor(Date.now() / 1000) + 3600, // Reset time in future
-          },
-        },
-      },
-    };
+  it('should get all necessary action inputs', async () => {
+    const mockGetInput = core.getInput as jest.Mock
 
-    const expectedRemaining =
-      mockRateLimitResponse.data.resources.core.remaining;
-    const expectedReset = mockRateLimitResponse.data.resources.core.reset;
+    mockGetInput.mockImplementation((name) => {
+      if (name === 'repo-token') return 'fake-token'
+      if (name === 'rate-limit-buffer') return '100'
+      if (name === 'days-inactive-issues') return '30'
+      if (name === 'days-inactive-prs') return '30'
+      if (name === 'lock-reason-issues') return 'off-topic'
+      if (name === 'lock-reason-prs') return 'off-topic'
+    })
 
-    const mockGetRateLimit = jest.fn().mockResolvedValue(mockRateLimitResponse);
+    await run()
 
-    mockGithub.getOctokit.mockReturnValue({
-      rest: {
-        rateLimit: {
-          get: mockGetRateLimit,
-        },
-      },
-    });
-
-    const rateLimitStatus = await checkRateLimit(
-      mockGithub.getOctokit("fake-token")
-    );
-
-    expect(mockGetRateLimit).toHaveBeenCalled();
-    expect(rateLimitStatus.remaining).toEqual(expectedRemaining);
-    expect(rateLimitStatus.resetTime).toEqual(
-      expectedReset - Math.floor(Date.now() / 1000)
-    );
-  });
-
-  it("should warn and stop processing if initial rate limit is exceeded", async () => {
-    // Set remaining rate limit to 0 to simulate rate limit exceeded
-    mockOctokit.rest.rateLimit.get.mockResolvedValueOnce({
-      data: {
-        resources: {
-          core: {
-            remaining: 0,
-            reset: Math.floor(Date.now() / 1000) + 3600, // Reset time in future
-          },
-        },
-      },
-    });
-
-    mockCore.getInput.mockImplementation((name) => {
-      if (name === "repo-token") return "fake-token";
-      if (name === "days-inactive-issues") return "30";
-      if (name === "days-inactive-prs") return "30";
-      if (name === "lock-reason-issues") return "off-topic";
-      if (name === "lock-reason-prs") return "off-topic";
-      return "";
-    });
-
-    await run();
-
-    expect(mockCore.warning).toHaveBeenCalledWith(
-      "Initial rate limit exceeded, stopping processing."
-    );
-  });
-
-  it("should process issues and pull requests if rate limit allows", async () => {
-    // Set remaining rate limit to 100 to simulate enough remaining calls
-    mockOctokit.rest.rateLimit.get.mockResolvedValueOnce({
-      data: {
-        resources: {
-          core: {
-            remaining: 100,
-            reset: Math.floor(Date.now() / 1000) + 3600, // Reset time in future
-          },
-        },
-      },
-    });
-
-    mockCore.getInput.mockImplementation((name) => {
-      if (name === "repo-token") return "fake-token";
-      if (name === "days-inactive-issues") return "30";
-      if (name === "days-inactive-prs") return "30";
-      if (name === "lock-reason-issues") return "off-topic";
-      if (name === "lock-reason-prs") return "off-topic";
-      return "";
-    });
-
-    // Mock response for listForRepo
-    mockOctokit.rest.issues.listForRepo.mockImplementation(
-      async ({ owner, repo, state, per_page, page }) => {
-        // Simulate fetching issues
-        if (page === 1) {
-          return {
-            data: [
-              {
-                number: 1,
-                pull_request: null,
-                updated_at: "2023-06-29T12:00:00Z", // Assuming this issue is inactive
-              },
-            ],
-          };
-        } else {
-          return {
-            data: [], // Simulate no more issues on subsequent pages
-          };
-        }
-      }
-    );
-
-    // Mock response for list
-    mockOctokit.rest.pulls.list.mockImplementation(
-      async ({ owner, repo, state, per_page, page }) => {
-        // Simulate fetching PRs
-        if (page === 1) {
-          return {
-            data: [
-              {
-                number: 1,
-                updated_at: "2023-05-29T12:00:00Z", // Assuming this issue is inactive
-              },
-            ],
-          };
-        } else {
-          return {
-            data: [], // Simulate no more PRs on subsequent pages
-          };
-        }
-      }
-    );
-
-    await run();
-
-    // Ensure processing functions were called
-    expect(mockOctokit.rest.issues.listForRepo).toHaveBeenCalled();
-    expect(mockOctokit.rest.pulls.list).toHaveBeenCalled();
-  });
-});
+    expect(mockGetInput).toHaveBeenCalledWith('repo-token')
+    expect(mockGetInput).toHaveBeenCalledWith('rate-limit-buffer')
+    expect(mockGetInput).toHaveBeenCalledWith('days-inactive-issues')
+    expect(mockGetInput).toHaveBeenCalledWith('days-inactive-prs')
+    expect(mockGetInput).toHaveBeenCalledWith('lock-reason-issues')
+    expect(mockGetInput).toHaveBeenCalledWith('lock-reason-prs')
+  })
+})

--- a/action.yml
+++ b/action.yml
@@ -11,6 +11,10 @@ inputs:
     description: "Token for the repository. Can be passed in using `{{ secrets.GITHUB_TOKEN }}`."
     required: false
     default: ${{ github.token }}
+  rate-limit-buffer:
+    description: "Buffer to avoid hitting the rate limit"
+    default: 100
+    required: false
   days-inactive-issues:
     description: "Number of days of inactivity before locking issues"
     default: 90

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import { context, getOctokit } from '@actions/github'
 export async function run(): Promise<void> {
   try {
     const token = core.getInput('repo-token')
+    const rateLimitBuffer = parseInt(core.getInput('rate-limit-buffer'), 10)
     const daysInactiveIssues = parseInt(
       core.getInput('days-inactive-issues'),
       10,
@@ -27,7 +28,8 @@ export async function run(): Promise<void> {
     const perPage = 100 // Batch size for processing
 
     const rateLimitStatus = await checkRateLimit(octokit)
-    if (rateLimitStatus.remaining > 0) {
+    if (rateLimitStatus.remaining > rateLimitBuffer) {
+      core.info('Sufficient rate limit available, starting processing.')
       // Process issues and PRs
       await processIssues(
         octokit,
@@ -36,6 +38,7 @@ export async function run(): Promise<void> {
         daysInactiveIssues,
         lockReasonIssues,
         perPage,
+        rateLimitBuffer,
       )
       await processPullRequests(
         octokit,
@@ -44,9 +47,10 @@ export async function run(): Promise<void> {
         daysInactivePRs,
         lockReasonPRs,
         perPage,
+        rateLimitBuffer,
       )
     } else {
-      core.warning('Initial rate limit exceeded, stopping processing.')
+      core.warning('Initial rate limit too low, stopping processing.')
     }
   } catch (error) {
     if (error instanceof Error) core.setFailed(error.message)
@@ -65,13 +69,15 @@ export async function processIssues(
     | 'spam'
     | undefined,
   perPage: number,
+  rateLimitBuffer: number,
   page: number = 1,
 ): Promise<void> {
   const now = new Date()
+  core.info(`Processing issues - page ${page} for ${owner}/${repo}.`)
 
   // Check rate limit before processing
   const rateLimitStatus = await checkRateLimit(octokit)
-  if (rateLimitStatus.remaining <= 0) {
+  if (rateLimitStatus.remaining <= rateLimitBuffer) {
     core.warning(
       `Rate limit exceeded, stopping further processing. Please wait for ${rateLimitStatus.resetTime} seconds before continuing.`,
     )
@@ -86,7 +92,11 @@ export async function processIssues(
     page: page,
   })
 
-  if (issues.data.length === 0) return // No more issues to process
+  // No more issues to process
+  if (issues.data.length === 0) {
+    core.info(`No more issues to process.`)
+    return
+  }
 
   for (const issue of issues.data) {
     // Check if it's not a PR
@@ -106,6 +116,10 @@ export async function processIssues(
         core.info(
           `Locked issue #${issue.number} due to ${daysInactiveIssues} days of inactivity.`,
         )
+      } else {
+        core.debug(
+          `Issue #${issue.number} has only ${daysDifference} days of inactivity.`,
+        )
       }
     }
   }
@@ -118,6 +132,7 @@ export async function processIssues(
     daysInactiveIssues,
     lockReasonIssues,
     perPage,
+    rateLimitBuffer,
     page + 1,
   )
 }
@@ -129,13 +144,15 @@ export async function processPullRequests(
   daysInactivePRs: number,
   lockReasonPRs: 'off-topic' | 'too heated' | 'resolved' | 'spam' | undefined,
   perPage: number,
+  rateLimitBuffer: number,
   page: number = 1,
 ): Promise<void> {
   const now = new Date()
+  core.info(`Processing pull requests - page ${page} for ${owner}/${repo}.`)
 
   // Check rate limit before processing
   const rateLimitStatus = await checkRateLimit(octokit)
-  if (rateLimitStatus.remaining <= 0) {
+  if (rateLimitStatus.remaining <= rateLimitBuffer) {
     core.warning(
       `Rate limit exceeded, stopping further processing. Please wait for ${rateLimitStatus.resetTime} seconds before continuing.`,
     )
@@ -150,7 +167,11 @@ export async function processPullRequests(
     page: page,
   })
 
-  if (pullRequests.data.length === 0) return // No more PRs to process
+  // No more PRs to process
+  if (pullRequests.data.length === 0) {
+    core.info(`No more PRs to process.`)
+    return
+  }
 
   for (const pr of pullRequests.data) {
     const lastUpdated = new Date(pr.updated_at)
@@ -168,6 +189,10 @@ export async function processPullRequests(
       core.info(
         `Locked PR #${pr.number} due to ${daysInactivePRs} days of inactivity.`,
       )
+    } else {
+      core.debug(
+        `PR #${pr.number} has only ${daysDifference} days of inactivity.`,
+      )
     }
   }
 
@@ -179,6 +204,7 @@ export async function processPullRequests(
     daysInactivePRs,
     lockReasonPRs,
     perPage,
+    rateLimitBuffer,
     page + 1,
   )
 }


### PR DESCRIPTION
As a possible solution to not completely go through the number of requests (of 5000 per hour), you can set a buffer (default of 100 requests). If the action comes below your set value during processing, then the action stops. In addition, there is also slightly more attention in the field of logging.