### PR TITLE
Refactor to use rest.search.issuesAndPullRequests

### DIFF
--- a/__tests__/fetch_lock.test.ts
+++ b/__tests__/fetch_lock.test.ts
@@ -1,0 +1,156 @@
+import * as core from '@actions/core'
+import * as github from '@actions/github'
+import {
+  lockItem,
+  fetchIssuesAndPRs,
+} from '../src/index'
+import { describe, expect, it, jest, beforeEach } from '@jest/globals'
+
+jest.mock('@actions/core')
+jest.mock('@actions/github')
+
+const mockCore = core as jest.Mocked<typeof core>
+const mockGithub = github as jest.Mocked<typeof github>
+
+describe('GitHub Action - Fetch & Lock', () => {
+  let mockOctokit: any
+  const currentDate = new Date('2024-07-01T00:00:00Z')
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    jest.useFakeTimers().setSystemTime(currentDate)
+
+    // Mock context.repo using Object.defineProperty
+    Object.defineProperty(mockGithub.context, 'repo', {
+      value: {
+        owner: 'test-owner',
+        repo: 'test-repo',
+      },
+      writable: true, // Ensure it can be modified
+    })
+
+    // Mock Octokit instance with rate limit functionality
+    mockOctokit = {
+      rest: {
+        search: {
+          issuesAndPullRequests: jest.fn(),
+        },
+        issues: {
+          lock: jest.fn(),
+        },
+        rateLimit: {
+          get: jest.fn().mockImplementation(() => {
+            // Default mock response for rate limit
+            return Promise.resolve({
+              data: {
+                resources: {
+                  core: {
+                    remaining: 5000,
+                    reset: Math.floor(Date.now() / 1000) + 3600, // Reset time in future
+                  },
+                },
+              },
+            })
+          }),
+        },
+      },
+    }
+
+    mockGithub.getOctokit.mockReturnValue(mockOctokit)
+  })
+
+  it('should warn and return if rate limit is under buffer', async () => {
+    mockOctokit.rest.rateLimit.get.mockResolvedValueOnce({
+      data: {
+        resources: {
+          core: {
+            remaining: 50,
+            reset: Math.floor(Date.now() / 1000) + 3600, // Reset time in future
+          },
+        },
+      },
+    })
+
+    await fetchIssuesAndPRs(mockOctokit, 'test-owner', 'test-repo', 100, 100)
+    expect(core.warning).toHaveBeenCalledWith(
+      'Rate limit exceeded, stopping further fetching. Please wait until Mon, 01 Jul 2024 01:00:00 GMT.',
+    )
+  })
+
+  it('should fetch issues and PRs', async () => {
+    await fetchIssuesAndPRs(mockOctokit, 'test-owner', 'test-repo', 100, 100)
+    expect(mockOctokit.rest.search.issuesAndPullRequests).toHaveBeenCalledWith({
+      q: 'repo:test-owner/test-repo state:closed is:unlocked',
+      per_page: 100,
+      page: 1,
+    })
+  })
+
+  it('should continue fetching issues and PRs if there are more pages', async () => {
+    const mockItemsPage1 = Array.from({ length: 100 }, (_, i) => ({
+      number: i + 1,
+      pull_request: false,
+      updated_at: new Date('2023-05-01T00:00:00Z').toISOString(),
+    }))
+    const mockItemsPage2 = Array.from({ length: 90 }, (_, i) => ({
+      number: 100 + i + 1,
+      pull_request: false,
+      updated_at: new Date('2023-05-01T00:00:00Z').toISOString(),
+    }))
+
+    mockOctokit.rest.search.issuesAndPullRequests
+      .mockResolvedValueOnce({ data: { items: mockItemsPage1 } })
+      .mockResolvedValueOnce({ data: { items: mockItemsPage2 } })
+
+    const result = await fetchIssuesAndPRs(
+      mockOctokit,
+      'test-owner',
+      'test-repo',
+      100,
+      100,
+    )
+
+    expect(mockOctokit.rest.search.issuesAndPullRequests).toHaveBeenCalledTimes(
+      2,
+    )
+    expect(result.length).toBe(190)
+  })
+
+  it('should handle errors during fetching issues and PRs', async () => {
+    mockOctokit.rest.search.issuesAndPullRequests.mockRejectedValueOnce(
+      new Error('API error'),
+    )
+
+    const result = await fetchIssuesAndPRs(
+      mockOctokit,
+      'test-owner',
+      'test-repo',
+      100,
+      100,
+    )
+
+    expect(core.setFailed).toHaveBeenCalledWith(
+      'Failed to fetch issues and PRs: API error',
+    )
+    expect(result).toEqual([])
+  })
+
+  it('should handle errors during closing issues and PRs', async () => {
+    const mockItems = [
+      { number: 1, title: 'Issue 1', updated_at: '2023-06-30T00:00:00Z' },
+    ]
+
+    mockOctokit.rest.search.issuesAndPullRequests.mockResolvedValueOnce({
+      data: { items: mockItems },
+    })
+
+    mockOctokit.rest.issues.lock.mockRejectedValueOnce(new Error('API error'))
+
+    await fetchIssuesAndPRs(mockOctokit, 'test-owner', 'test-repo', 100, 100)
+    await lockItem(mockOctokit, 'test-owner', 'test-repo', 1, 'off-topic')
+
+    expect(core.setFailed).toHaveBeenCalledWith(
+      'Failed to lock issue/PR #1: API error',
+    )
+  })
+})

--- a/__tests__/pull_requests.test.ts
+++ b/__tests__/pull_requests.test.ts
@@ -1,6 +1,6 @@
 import * as core from '@actions/core'
 import * as github from '@actions/github'
-import { processPullRequests } from '../src/index'
+import { processPullRequests, fetchIssuesAndPRs } from '../src/index'
 import { describe, expect, it, jest, beforeEach } from '@jest/globals'
 
 jest.mock('@actions/core')
@@ -11,9 +11,11 @@ const mockGithub = github as jest.Mocked<typeof github>
 
 describe('GitHub Action - Lock PRs', () => {
   let mockOctokit: any
+  const currentDate = new Date('2024-07-01T00:00:00Z')
 
   beforeEach(() => {
     jest.clearAllMocks()
+    jest.useFakeTimers().setSystemTime(currentDate)
 
     // Mock context.repo using Object.defineProperty
     Object.defineProperty(mockGithub.context, 'repo', {
@@ -27,11 +29,11 @@ describe('GitHub Action - Lock PRs', () => {
     // Mock Octokit instance with rate limit functionality
     mockOctokit = {
       rest: {
+        search: {
+          issuesAndPullRequests: jest.fn(),
+        },
         issues: {
           lock: jest.fn(),
-        },
-        pulls: {
-          list: jest.fn(),
         },
         rateLimit: {
           get: jest.fn().mockImplementation(() => {
@@ -54,7 +56,7 @@ describe('GitHub Action - Lock PRs', () => {
     mockGithub.getOctokit.mockReturnValue(mockOctokit)
   })
 
-  it('should process closed PRs and lock inactive ones', async () => {
+  it('should process closed PRs and lock inactive ones (with custom reason)', async () => {
     mockCore.getInput.mockImplementation((name) => {
       if (name === 'repo-token') return 'fake-token'
       if (name === 'days-inactive-prs') return '30'
@@ -62,271 +64,95 @@ describe('GitHub Action - Lock PRs', () => {
       return ''
     })
 
-    mockOctokit.rest.pulls.list.mockImplementation(
-      async ({ owner, repo, state, per_page, page }) => {
-        // Simulate fetching PRs
-        if (page === 1) {
-          return {
-            data: [
-              {
-                number: 1,
-                title: 'Test PR',
-                updated_at: '2023-05-29T12:00:00Z', // Assuming this issue is inactive
-              },
-            ],
-          }
-        } else {
-          return {
-            data: [], // Simulate no more PRs on subsequent pages
-          }
-        }
-      },
-    )
+    const mockItems = [
+      { number: 1, title: 'PR 1', updated_at: "2024-06-30T00:00:00Z" }, // Active issue
+      { number: 2, title: 'PR 2', updated_at: "2024-06-30T00:00:00Z" }, // Active issue
+      {
+        number: 3,
+        title: 'PR 3',
+        updated_at: new Date(
+          Date.now() - 31 * 24 * 60 * 60 * 1000,
+        ).toISOString(),
+      }, // Inactive issue
+    ]
 
-    // @ts-ignore - Ignore missing properties
-    const mockLock = jest.fn().mockResolvedValue({})
-    const lockedPRs: { number: number; title: string }[] = []
-    mockOctokit.rest.issues.lock.mockImplementationOnce(mockLock)
+    mockOctokit.rest.search.issuesAndPullRequests.mockResolvedValueOnce({
+      data: { items: mockItems },
+    })
 
+    const mockSetOutput = jest.spyOn(core, 'setOutput')
+    const mockInfo = jest.spyOn(core, 'info')
+
+    // Run the action
+    await fetchIssuesAndPRs(mockOctokit, 'test-owner', 'test-repo', 100, 10)
     await processPullRequests(
       mockOctokit,
       'test-owner',
       'test-repo',
+      mockItems,
       30,
-      undefined,
-      100,
-      100,
-      lockedPRs,
+      'off-topic',
     )
 
-    expect(mockOctokit.rest.pulls.list).toHaveBeenCalledWith({
-      owner: 'test-owner',
-      repo: 'test-repo',
-      state: 'closed',
-      per_page: 100,
-      page: 1,
-    })
-
+    // Assert locking function calls
+    expect(mockOctokit.rest.issues.lock).toHaveBeenCalledTimes(1)
     expect(mockOctokit.rest.issues.lock).toHaveBeenCalledWith({
       owner: 'test-owner',
       repo: 'test-repo',
-      issue_number: 1,
+      issue_number: 3,
+      lock_reason: 'off-topic',
     })
 
-    expect(mockCore.info).toHaveBeenCalledWith(
-      'Locked PR #1 due to 30 days of inactivity.',
+    // Assert info message
+    expect(mockInfo).toHaveBeenCalledWith(
+      'Locked PR #3 due to 30 days of inactivity.',
     )
 
-    // Ensure lockedPRs array is updated correctly
-    expect(lockedPRs).toEqual([{ number: 1, title: 'Test PR' }])
-
-    // Ensure outputs are set correctly
-    expect(mockCore.setOutput).toHaveBeenCalledWith(
+    // Assert setOutput called with locked PRs
+    expect(mockSetOutput).toHaveBeenCalledWith(
       'locked-prs',
-      JSON.stringify([{ number: 1, title: 'Test PR' }]),
+      JSON.stringify([{ number: 3, title: 'PR 3' }]),
     )
   })
 
-  it('should process multiple pages of closed PRs', async () => {
+  it('should not lock PRs that are less then 30 days inactive', async () => {
     mockCore.getInput.mockImplementation((name) => {
       if (name === 'repo-token') return 'fake-token'
       if (name === 'days-inactive-prs') return '30'
-      if (name === 'lock-reason-prs') return 'off-topic'
       return ''
     })
 
-    // Mock response for pulls.list
-    mockOctokit.rest.pulls.list.mockImplementation(
-      async ({ owner, repo, state, per_page, page }) => {
-        // Simulate fetching PRs
-        if (page === 1) {
-          return {
-            data: Array(per_page).fill({
-              number: 1,
-              title: 'Test PR',
-              updated_at: '2023-05-29T12:00:00Z', // Assuming this PR is inactive
-            }),
-          }
-        } else {
-          return {
-            data: [], // Simulate no more PRs on subsequent pages
-          }
-        }
-      },
-    )
+    const mockItems = [
+      { number: 1, title: 'PR 1', updated_at: "2024-06-30T00:00:00Z" }, // Active issue
+      { number: 2, title: 'PR 2', updated_at: "2024-06-30T00:00:00Z" }, // Active issue
+    ]
 
-    // @ts-ignore - Ignore missing properties
-    const mockLock = jest.fn().mockResolvedValue({})
-    const lockedPRs: { number: number; title: string }[] = []
-    mockOctokit.rest.issues.lock.mockImplementationOnce(mockLock)
+    mockOctokit.rest.search.issuesAndPullRequests.mockResolvedValueOnce({
+      data: { items: mockItems },
+    })
 
+    const mockSetOutput = jest.spyOn(core, 'setOutput')
+
+    // Run the action
+    await fetchIssuesAndPRs(mockOctokit, 'test-owner', 'test-repo', 100, 10)
     await processPullRequests(
       mockOctokit,
       'test-owner',
       'test-repo',
+      mockItems,
       30,
-      'off-topic',
-      100,
-      100,
-      lockedPRs,
+      'resolved',
     )
 
-    expect(mockOctokit.rest.pulls.list).toHaveBeenCalledWith({
-      owner: 'test-owner',
-      repo: 'test-repo',
-      state: 'closed',
-      per_page: 100,
-      page: 1,
-    })
-  })
-
-  it('should not lock PRs that are already locked', async () => {
-    mockCore.getInput.mockImplementation((name) => {
-      if (name === 'repo-token') return 'fake-token'
-      if (name === 'days-inactive-prs') return '30'
-      if (name === 'lock-reason-prs') return 'off-topic'
-      return ''
-    })
-
-    // Mock response for pulls.list
-    mockOctokit.rest.pulls.list.mockImplementation(
-      async ({ owner, repo, state, per_page, page }) => {
-        // Simulate fetching PRs
-        if (page === 1) {
-          return {
-            data: [
-              {
-                number: 1,
-                title: 'Test PR',
-                updated_at: '2023-05-29T12:00:00Z', // Assuming this PR is inactive
-                locked: true,
-              },
-            ],
-          }
-        } else {
-          return {
-            data: [], // Simulate no more PRs on subsequent pages
-          }
-        }
-      },
+    // Assert debug messages
+    expect(core.debug).toHaveBeenCalledWith(
+      'PR #1 has only 1 days of inactivity.',
     )
 
-    // @ts-ignore - Ignore missing properties
-    const mockLock = jest.fn().mockResolvedValue({})
-    const lockedPRs: { number: number; title: string }[] = []
-    mockOctokit.rest.issues.lock.mockImplementationOnce(mockLock)
-
-    await processPullRequests(
-      mockOctokit,
-      'test-owner',
-      'test-repo',
-      30,
-      'off-topic',
-      100,
-      100,
-      lockedPRs,
-    )
-
-    expect(mockOctokit.rest.pulls.list).toHaveBeenCalledWith({
-      owner: 'test-owner',
-      repo: 'test-repo',
-      state: 'closed',
-      per_page: 100,
-      page: 1,
-    })
-
+    // Assert no locking function call
     expect(mockOctokit.rest.issues.lock).not.toHaveBeenCalled()
-    expect(core.debug).toHaveBeenCalledWith('PR #1 is already locked.')
-  })
 
-  it('should not lock PRs that are less than 30 days inactive', async () => {
-    mockCore.getInput.mockImplementation((name) => {
-      if (name === 'repo-token') return 'fake-token'
-      if (name === 'days-inactive-prs') return '30'
-      if (name === 'lock-reason-prs') return 'off-topic'
-      return ''
-    })
-
-    // Mock response for pulls.list
-    mockOctokit.rest.pulls.list.mockImplementation(
-      async ({ owner, repo, state, per_page, page }) => {
-        // Simulate fetching issues
-        if (page === 1) {
-          return {
-            data: [
-              {
-                number: 1,
-                updated_at: new Date().toISOString(), // Date is current
-              },
-            ],
-          }
-        } else {
-          return {
-            data: [], // Simulate no more issues on subsequent pages
-          }
-        }
-      },
-    )
-
-    // @ts-ignore - Ignore missing properties
-    const mockLock = jest.fn().mockResolvedValue({})
-    mockOctokit.rest.issues.lock.mockImplementationOnce(mockLock)
-
-    await processPullRequests(
-      mockOctokit,
-      'test-owner',
-      'test-repo',
-      30,
-      'off-topic',
-      100,
-      100,
-    )
-
-    expect(mockOctokit.rest.pulls.list).toHaveBeenCalledWith({
-      owner: 'test-owner',
-      repo: 'test-repo',
-      state: 'closed',
-      per_page: 100,
-      page: 1,
-    })
-
-    expect(mockLock).not.toHaveBeenCalled() // Ensure lock function is not called
-  })
-
-  it('should warn when rate limit is exceeded during PR locking', async () => {
-    // Set remaining rate limit to 0 to simulate rate limit exceeded
-    mockOctokit.rest.rateLimit.get.mockResolvedValueOnce({
-      data: {
-        resources: {
-          core: {
-            remaining: 0,
-            reset: Math.floor(Date.now() / 1000) + 3600, // Reset time in future
-          },
-        },
-      },
-    })
-
-    mockCore.getInput.mockImplementation((name) => {
-      if (name === 'repo-token') return 'fake-token'
-      if (name === 'days-inactive-prs') return '30'
-      if (name === 'lock-reason-prs') return 'off-topic'
-      return ''
-    })
-
-    await processPullRequests(
-      mockOctokit,
-      'test-owner',
-      'test-repo',
-      30,
-      'off-topic',
-      100,
-      100,
-    )
-
-    expect(mockCore.warning).toHaveBeenCalledWith(
-      expect.stringContaining('Rate limit exceeded'),
-    )
-    expect(mockOctokit.rest.pulls.list).not.toHaveBeenCalled()
-    expect(mockOctokit.rest.issues.lock).not.toHaveBeenCalled()
+    // Assert setOutput not called for locked prs
+    expect(mockSetOutput).toHaveBeenCalledWith('locked-prs', JSON.stringify([]))
   })
 })

--- a/__tests__/ratelimit.test.ts
+++ b/__tests__/ratelimit.test.ts
@@ -27,12 +27,11 @@ describe('GitHub Action - Rate Limit Handling', () => {
     // Mock Octokit instance with rate limit functionality
     mockOctokit = {
       rest: {
-        issues: {
-          listForRepo: jest.fn(),
-          lock: jest.fn(),
+        search: {
+          issuesAndPullRequests: jest.fn(),
         },
-        pulls: {
-          list: jest.fn(),
+        issues: {
+          lock: jest.fn(),
         },
         rateLimit: {
           get: jest.fn().mockImplementation(() => {
@@ -156,78 +155,5 @@ describe('GitHub Action - Rate Limit Handling', () => {
     expect(mockCore.warning).toHaveBeenCalledWith(
       'Initial rate limit too low, stopping processing.',
     )
-  })
-
-  it('should process issues and pull requests if rate limit allows', async () => {
-    // Set remaining rate limit to 100 to simulate enough remaining calls
-    mockOctokit.rest.rateLimit.get.mockResolvedValueOnce({
-      data: {
-        resources: {
-          core: {
-            remaining: 200,
-            reset: Math.floor(Date.now() / 1000) + 3600, // Reset time in future
-          },
-        },
-      },
-    })
-
-    mockCore.getInput.mockImplementation((name) => {
-      if (name === 'repo-token') return 'fake-token'
-      if (name === 'rate-limit-buffer') return '100'
-      if (name === 'days-inactive-issues') return '30'
-      if (name === 'days-inactive-prs') return '30'
-      if (name === 'lock-reason-issues') return 'off-topic'
-      if (name === 'lock-reason-prs') return 'off-topic'
-      return ''
-    })
-
-    // Mock response for listForRepo
-    mockOctokit.rest.issues.listForRepo.mockImplementation(
-      async ({ owner, repo, state, per_page, page }) => {
-        // Simulate fetching issues
-        if (page === 1) {
-          return {
-            data: [
-              {
-                number: 1,
-                pull_request: null,
-                updated_at: '2023-06-29T12:00:00Z', // Assuming this issue is inactive
-              },
-            ],
-          }
-        } else {
-          return {
-            data: [], // Simulate no more issues on subsequent pages
-          }
-        }
-      },
-    )
-
-    // Mock response for list
-    mockOctokit.rest.pulls.list.mockImplementation(
-      async ({ owner, repo, state, per_page, page }) => {
-        // Simulate fetching PRs
-        if (page === 1) {
-          return {
-            data: [
-              {
-                number: 1,
-                updated_at: '2023-05-29T12:00:00Z', // Assuming this issue is inactive
-              },
-            ],
-          }
-        } else {
-          return {
-            data: [], // Simulate no more PRs on subsequent pages
-          }
-        }
-      },
-    )
-
-    await run()
-
-    // Ensure processing functions were called
-    expect(mockOctokit.rest.issues.listForRepo).toHaveBeenCalled()
-    expect(mockOctokit.rest.pulls.list).toHaveBeenCalled()
   })
 })

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,12 +1,23 @@
 import * as core from '@actions/core'
 import { context, getOctokit } from '@actions/github'
 
+/**
+ * Rate limit status object.
+ * @property remaining Number of requests remaining.
+ * @property resetTime Time when the rate limit resets.
+ * @property resetTimeHumanReadable Human-readable time when the rate limit resets.
+ */
 interface RateLimitStatus {
   remaining: number
   resetTime: number
   resetTimeHumanReadable: string
 }
 
+/**
+ * Main function to run the action.
+ * @returns Promise that resolves when the action is completed.
+ * @throws Error if the action fails.
+ */
 export async function run(): Promise<void> {
   try {
     const token = core.getInput('repo-token')
@@ -39,27 +50,41 @@ export async function run(): Promise<void> {
     const rateLimitStatus = (await checkRateLimit(octokit)) as RateLimitStatus
     if (rateLimitStatus.remaining > rateLimitBuffer) {
       core.info('Sufficient rate limit available, starting processing.')
+
+      // Fetch all relevant issues and PRs
+      const items = await fetchIssuesAndPRs(
+        octokit,
+        owner,
+        repo,
+        perPage,
+        rateLimitBuffer,
+      )
+      const issuesList = items.filter((item) => !item.pull_request)
+      const pullRequestsList = items.filter((item) => item.pull_request)
+
       // Process issues and PRs in parallel
       await Promise.all([
         processIssues(
           octokit,
           owner,
           repo,
+          issuesList,
           daysInactiveIssues,
           lockReasonIssues,
-          perPage,
-          rateLimitBuffer,
         ),
         processPullRequests(
           octokit,
           owner,
           repo,
+          pullRequestsList,
           daysInactivePRs,
           lockReasonPRs,
-          perPage,
-          rateLimitBuffer,
         ),
       ])
+
+      // Check rate limit after processing
+      await checkRateLimit(octokit)
+      core.info('Processing completed.')
     } else {
       core.warning('Initial rate limit too low, stopping processing.')
     }
@@ -70,10 +95,88 @@ export async function run(): Promise<void> {
   }
 }
 
+/**
+ * Fetches closed issues and pull requests from a GitHub repository.
+ * @param octokit Octokit instance.
+ * @param owner Owner of the repository.
+ * @param repo Name of the repository.
+ * @param perPage Number of items to fetch per page.
+ * @param rateLimitBuffer Buffer for remaining rate limit checks.
+ * @param page Page number to fetch.
+ * @param allItems Array of fetched items.
+ * @returns Promise that resolves to an array of fetched items.
+ * @throws Error if fetching fails.
+ */
+export async function fetchIssuesAndPRs(
+  octokit: ReturnType<typeof getOctokit>,
+  owner: string,
+  repo: string,
+  perPage: number,
+  rateLimitBuffer: number,
+  page: number = 1,
+  allItems: any[] = [],
+): Promise<any[]> {
+  core.info(`Fetching issues and PRs on page ${page}`)
+
+  try {
+    // Check rate limit before fetching
+    const rateLimitStatus = await checkRateLimit(octokit)
+    if (rateLimitStatus.remaining <= rateLimitBuffer) {
+      core.warning(
+        `Rate limit exceeded, stopping further fetching. Please wait until ${rateLimitStatus.resetTimeHumanReadable}.`,
+      )
+      return allItems
+    }
+
+    const query = `repo:${owner}/${repo} state:closed is:unlocked`
+    const results = await octokit.rest.search.issuesAndPullRequests({
+      q: query,
+      per_page: perPage,
+      page: page,
+    })
+
+    const fetchedItems = results.data.items
+    allItems.push(...results.data.items)
+
+    if (fetchedItems.length === perPage) {
+      // Fetch next batch
+      return fetchIssuesAndPRs(
+        octokit,
+        owner,
+        repo,
+        perPage,
+        rateLimitBuffer,
+        page + 1,
+        allItems,
+      )
+    } else {
+      core.info(`Total issues and PRs fetched: ${allItems.length}`)
+      return allItems
+    }
+  } catch (error) {
+    if (error instanceof Error) {
+      core.setFailed(`Failed to fetch issues and PRs: ${error.message}`)
+    }
+    return allItems
+  }
+}
+
+/**
+ * Processes a list of issues and locks them if they are inactive.
+ * @param octokit Octokit instance.
+ * @param owner Owner of the repository.
+ * @param repo Name of the repository.
+ * @param issuesList List of issues to process.
+ * @param daysInactiveIssues Number of days of inactivity to lock an issue.
+ * @param lockReasonIssues Reason for locking the issue.
+ * @returns Promise that resolves when all issues are processed.
+ * @throws Error if an issue fails to process.
+ */
 export async function processIssues(
   octokit: ReturnType<typeof getOctokit>,
   owner: string,
   repo: string,
+  issuesList: any[],
   daysInactiveIssues: number,
   lockReasonIssues:
     | 'off-topic'
@@ -81,183 +184,119 @@ export async function processIssues(
     | 'resolved'
     | 'spam'
     | undefined,
-  perPage: number,
-  rateLimitBuffer: number,
-  lockedIssues: { number: number; title: string }[] = [],
-  page: number = 1,
 ): Promise<void> {
   const now = new Date()
-  core.info(`Processing issues on page ${page}`)
+  const lockedIssues: { number: number; title: string }[] = []
 
-  // Check rate limit before processing
-  const rateLimitStatus = await checkRateLimit(octokit)
-  if (rateLimitStatus.remaining <= rateLimitBuffer) {
-    core.warning(
-      `Rate limit exceeded, stopping further processing. Please wait until ${rateLimitStatus.resetTimeHumanReadable}.`,
-    )
-    return
-  }
+  for (const issue of issuesList) {
+    const lastUpdated = new Date(issue.updated_at)
+    const daysDifference =
+      (now.getTime() - lastUpdated.getTime()) / (1000 * 60 * 60 * 24)
 
-  try {
-    const issues = await octokit.rest.issues.listForRepo({
-      owner,
-      repo,
-      state: 'closed',
-      per_page: perPage,
-      page: page,
-    })
-
-    for (const issue of issues.data) {
-      // Check if it's not a PR
-      if (!issue.pull_request && !issue.locked) {
-        const lastUpdated = new Date(issue.updated_at)
-        const daysDifference =
-          (now.getTime() - lastUpdated.getTime()) / (1000 * 60 * 60 * 24)
-
-        if (daysDifference > daysInactiveIssues) {
-          // Construct parameters for the lock request
-          const lockParams: any = {
-            owner,
-            repo,
-            issue_number: issue.number,
-          }
-          if (lockReasonIssues) {
-            lockParams.lock_reason = lockReasonIssues
-          }
-
-          // Lock the issue
-          await octokit.rest.issues.lock(lockParams)
-          core.info(
-            `Locked issue #${issue.number} due to ${daysInactiveIssues} days of inactivity.`,
-          )
-          // Add the locked issue to the list
-          lockedIssues.push({ number: issue.number, title: issue.title })
-        } else {
-          core.debug(
-            `Issue #${issue.number} has only ${daysDifference} days of inactivity.`,
-          )
-        }
-      } else if (issue.locked) {
-        core.debug(`Issue #${issue.number} is already locked.`)
-      }
-    }
-
-    if (issues.data.length === perPage) {
-      // Process next batch
-      await processIssues(
-        octokit,
-        owner,
-        repo,
-        daysInactiveIssues,
-        lockReasonIssues,
-        perPage,
-        rateLimitBuffer,
-        lockedIssues,
-        page + 1,
+    if (daysDifference > daysInactiveIssues) {
+      await lockItem(octokit, owner, repo, issue.number, lockReasonIssues)
+      core.info(
+        `Locked issue #${issue.number} due to ${daysInactiveIssues} days of inactivity.`,
       )
+      // Add the locked issue to the list
+      lockedIssues.push({ number: issue.number, title: issue.title })
     } else {
-      core.info(`No more issues to process.`)
-      // Set the output for locked issues
-      core.setOutput('locked-issues', JSON.stringify(lockedIssues))
-    }
-  } catch (error) {
-    if (error instanceof Error) {
-      core.setFailed(`Failed to process issues: ${error.message}`)
+      core.debug(
+        `Issue #${issue.number} has only ${daysDifference} days of inactivity.`,
+      )
     }
   }
+
+  // Set the output for locked issues
+  core.setOutput('locked-issues', JSON.stringify(lockedIssues))
 }
 
+/**
+ * Processes a list of pull requests and locks them if they are inactive.
+ * @param octokit Octokit instance.
+ * @param owner Owner of the repository.
+ * @param repo Name of the repository.
+ * @param pullRequestsList List of pull requests to process.
+ * @param daysInactivePRs Number of days of inactivity to lock a pull request.
+ * @param lockReasonPRs Reason for locking the pull request.
+ * @returns Promise that resolves when all pull requests are processed.
+ * @throws Error if a pull request fails to process.
+ */
 export async function processPullRequests(
   octokit: ReturnType<typeof getOctokit>,
   owner: string,
   repo: string,
+  pullRequestsList: any[],
   daysInactivePRs: number,
   lockReasonPRs: 'off-topic' | 'too heated' | 'resolved' | 'spam' | undefined,
-  perPage: number,
-  rateLimitBuffer: number,
-  lockedPRs: { number: number; title: string }[] = [],
-  page: number = 1,
 ): Promise<void> {
   const now = new Date()
-  core.info(`Processing PRs on page ${page}`)
+  const lockedPRs: { number: number; title: string }[] = []
 
-  // Check rate limit before processing
-  const rateLimitStatus = await checkRateLimit(octokit)
-  if (rateLimitStatus.remaining <= rateLimitBuffer) {
-    core.warning(
-      `Rate limit exceeded, stopping further processing. Please wait until ${rateLimitStatus.resetTimeHumanReadable}`,
-    )
-    return
+  for (const pr of pullRequestsList) {
+    const lastUpdated = new Date(pr.updated_at)
+    const daysDifference =
+      (now.getTime() - lastUpdated.getTime()) / (1000 * 60 * 60 * 24)
+
+    if (daysDifference > daysInactivePRs) {
+      await lockItem(octokit, owner, repo, pr.number, lockReasonPRs)
+      core.info(
+        `Locked PR #${pr.number} due to ${daysInactivePRs} days of inactivity.`,
+      )
+      // Add the locked PR to the list
+      lockedPRs.push({ number: pr.number, title: pr.title })
+    } else {
+      core.debug(
+        `PR #${pr.number} has only ${daysDifference} days of inactivity.`,
+      )
+    }
+  }
+  // Set the output for locked PRs
+  core.setOutput('locked-prs', JSON.stringify(lockedPRs))
+}
+
+/**
+ * Locks an issue or pull request on a GitHub repository.
+ * @param octokit Octokit instance.
+ * @param owner Owner of the repository.
+ * @param repo Name of the repository.
+ * @param itemNumber Number of the issue or pull request.
+ * @param lockReason Reason for locking the issue or pull request.
+ * @returns Promise that resolves when the item is locked.
+ * @throws Error if the item fails to lock.
+ */
+export async function lockItem(
+  octokit: ReturnType<typeof getOctokit>,
+  owner: string,
+  repo: string,
+  itemNumber: number,
+  lockReason: 'off-topic' | 'too heated' | 'resolved' | 'spam' | undefined,
+): Promise<void> {
+  // Construct parameters for the lock request
+  const lockParams: any = {
+    owner,
+    repo,
+    issue_number: itemNumber,
+  }
+  if (lockReason) {
+    lockParams.lock_reason = lockReason
   }
 
   try {
-    const pullRequests = await octokit.rest.pulls.list({
-      owner,
-      repo,
-      state: 'closed',
-      per_page: perPage,
-      page: page,
-    })
-
-    for (const pr of pullRequests.data) {
-      if (!pr.locked) {
-        const lastUpdated = new Date(pr.updated_at)
-        const daysDifference =
-          (now.getTime() - lastUpdated.getTime()) / (1000 * 60 * 60 * 24)
-
-        if (daysDifference > daysInactivePRs) {
-          // Construct parameters for the lock request
-          const lockParams: any = {
-            owner,
-            repo,
-            issue_number: pr.number,
-          }
-          if (lockReasonPRs) {
-            lockParams.lock_reason = lockReasonPRs
-          }
-
-          // Lock the PR
-          await octokit.rest.issues.lock(lockParams)
-          core.info(
-            `Locked PR #${pr.number} due to ${daysInactivePRs} days of inactivity.`,
-          )
-          // Add the locked PR to the list
-          lockedPRs.push({ number: pr.number, title: pr.title })
-        } else {
-          core.debug(
-            `PR #${pr.number} has only ${daysDifference} days of inactivity.`,
-          )
-        }
-      } else if (pr.locked) {
-        core.debug(`PR #${pr.number} is already locked.`)
-      }
-    }
-
-    if (pullRequests.data.length === perPage) {
-      // Process next batch
-      await processPullRequests(
-        octokit,
-        owner,
-        repo,
-        daysInactivePRs,
-        lockReasonPRs,
-        perPage,
-        rateLimitBuffer,
-        lockedPRs,
-        page + 1,
-      )
-    } else {
-      core.info(`No more PRs to process.`)
-      // Set the output for locked PRs
-      core.setOutput('locked-prs', JSON.stringify(lockedPRs))
-    }
+    // Lock the issue or PR
+    await octokit.rest.issues.lock(lockParams)
   } catch (error) {
     if (error instanceof Error) {
-      core.setFailed(`Failed to process pull requests: ${error.message}`)
+      core.setFailed(`Failed to lock issue/PR #${itemNumber}: ${error.message}`)
     }
   }
 }
 
+/**
+ * Checks the current rate limit status of GitHub API.
+ * @param octokit Octokit instance.
+ * @returns Promise that resolves to a RateLimitStatus object.
+ */
 export async function checkRateLimit(
   octokit: ReturnType<typeof getOctokit>,
 ): Promise<RateLimitStatus> {


### PR DESCRIPTION
Thanks to this refactor, we can search very specifically for issues and pull requests that are closed but not yet locked.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
	- Added and updated test cases for fetching and locking GitHub issues and pull requests.
	- Added new test scenarios for handling rate limits and different activity statuses.
	- Improved test coverage for error handling and debug messaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->